### PR TITLE
chore: bump pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"keywords": [],
 	"author": "",
 	"license": "ISC",
-	"packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
+	"packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.14",
 		"@changesets/changelog-github": "^0.7.0",
@@ -52,17 +52,5 @@
 	},
 	"simple-git-hooks": {
 		"pre-commit": ".githooks/pre-commit.sh"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"simple-git-hooks"
-		],
-		"overrides": {
-			"@kheopskit/core": "link:packages/core",
-			"@kheopskit/react": "link:packages/react",
-			"axios@>=1.0.0 <1.15.2": "^1.15.2",
-			"postcss@<8.5.10": "^8.5.10",
-			"hono@<4.12.18": "^4.12.18"
-		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2125,6 +2125,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,18 +2,22 @@ packages:
   - examples/*
   - packages/*
   - .
-ignoredBuiltDependencies:
-  - bufferutil
-  - keccak
-  - simple-git-hooks
-  - utf-8-validate
-onlyBuiltDependencies:
-  - "@biomejs/biome"
-  - "@tailwindcss/oxide"
-  - esbuild
+allowBuilds:
+  "@biomejs/biome": true
+  "@reown/appkit": false
+  "@tailwindcss/oxide": true
+  bufferutil: false
+  esbuild: true
+  keccak: false
+  sharp: false
+  simple-git-hooks: false
+  utf-8-validate: false
 overrides:
   "@kheopskit/core": link:packages/core
   "@kheopskit/react": link:packages/react
+  "axios@>=1.0.0 <1.15.2": ^1.15.2
+  "postcss@<8.5.10": ^8.5.10
+  "hono@<4.12.18": ^4.12.18
 
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## What

Bumps the pinned package manager from pnpm 10.28.0 to **pnpm 11.6.0** and migrates config for pnpm 11's breaking changes:

- **`pnpm` field in `package.json` is no longer read** → moved its contents to `pnpm-workspace.yaml`. Notably this includes the `axios`/`postcss`/`hono` security overrides — without this migration pnpm 11 silently drops them.
- **`onlyBuiltDependencies` / `ignoredBuiltDependencies` were removed** → replaced with the new `allowBuilds` map. Entries preserve the exact prior behavior; `@reown/appkit` and `sharp` (newly flagged by pnpm as having build scripts) are set to `false`, matching their previously-unapproved state.

`pnpm-lock.yaml` gains one metadata line: pnpm 11 records npm deprecation notices in the lockfile (here for the transitive dep `@safe-global/safe-gateway-typescript-sdk@3.23.1`). No versions or resolutions changed.

CI uses `pnpm/action-setup@v4` with no explicit version, so it picks up the new `packageManager` pin automatically.

## Verification

- `pnpm install` clean from a purged modules dir
- `pnpm build` ✅
- `pnpm typecheck` ✅ (all 5 workspace projects)
- `pnpm test` ✅ (275 tests, 23 files)

## Note (pre-existing, unchanged here)

`simple-git-hooks` is configured in `package.json` (`pre-commit: .githooks/pre-commit.sh`) but its install script has been blocked by `ignoredBuiltDependencies` all along — there are no hooks in `.git/hooks`, so the pre-commit hook was never actually active. This PR preserves that status quo (`simple-git-hooks: false`). If the hook is meant to run, flip it to `true` (or add a `prepare` script) in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
