### PR TITLE
chore: realign version so the release publishes 5.0.0 (not 6.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kheopskit",
-	"version": "5.0.0",
+	"version": "4.0.0",
 	"private": true,
 	"description": "",
 	"engines": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,26 +1,5 @@
 # @kheopskit/core
 
-## 5.0.0
-
-### Major Changes
-
-- WalletConnect is now a single, platform-less connector instead of one wallet per platform.
-
-  A WalletConnect session is shared across every namespace and is established in a single pairing, so `wallets` now contains exactly one `WalletConnectWallet` (`type: "walletconnect"`, no `platform`) with a `platforms: WalletPlatform[]` array of the namespaces the live session actually approved. Its accounts still appear in `accounts`, each carrying its own `platform`.
-
-  This fixes the previous behaviour where each platform showed its own "WalletConnect" connect button — only the first did anything, and disconnecting one tore down the whole session.
-
-  BREAKING CHANGES:
-
-  - Removed `AppKitWallet`, `PolkadotAppKitWallet`, `EthereumAppKitWallet`, `SolanaAppKitWallet`. Use `WalletConnectWallet` together with the `isWalletConnectWallet(wallet)` type guard (exported from `@kheopskit/core` and from each platform entry point).
-  - `WalletType` is now `"injected" | "walletconnect"` (`"appKit"` removed).
-  - The WalletConnect entry has no `platform` field — narrow with `isWalletConnectWallet(wallet)` before reading `wallet.platform`. Per-platform wallet filters (`wallets.filter(w => w.platform === "polkadot")`) no longer match it; find it with `wallets.find(isWalletConnectWallet)`.
-  - Connect/disconnect are session-wide: connecting opens one modal and the wallet approves whichever namespaces it supports; a namespace cannot be added to a live session (disconnect and re-pair to change the approved set).
-
-### Patch Changes
-
-- [`ef02b3a`](https://github.com/kheopskit/kheopskit/commit/ef02b3ade87c04c1732e746f4490b70b94b85451) Thanks [@0xKheops](https://github.com/0xKheops)! - fix: wallet connect ethereum
-
 ## 4.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kheopskit/core",
-	"version": "5.0.0",
+	"version": "4.0.0",
 	"description": "",
 	"private": false,
 	"sideEffects": false,

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @kheopskit/react
 
-## 5.0.0
-
-### Major Changes
-
-- WalletConnect is now a single, platform-less connector instead of one wallet per platform.
-
-  A WalletConnect session is shared across every namespace and is established in a single pairing, so `wallets` now contains exactly one `WalletConnectWallet` (`type: "walletconnect"`, no `platform`) with a `platforms: WalletPlatform[]` array of the namespaces the live session actually approved. Its accounts still appear in `accounts`, each carrying its own `platform`.
-
-  This fixes the previous behaviour where each platform showed its own "WalletConnect" connect button — only the first did anything, and disconnecting one tore down the whole session.
-
-  BREAKING CHANGES:
-
-  - Removed `AppKitWallet`, `PolkadotAppKitWallet`, `EthereumAppKitWallet`, `SolanaAppKitWallet`. Use `WalletConnectWallet` together with the `isWalletConnectWallet(wallet)` type guard (exported from `@kheopskit/core` and from each platform entry point).
-  - `WalletType` is now `"injected" | "walletconnect"` (`"appKit"` removed).
-  - The WalletConnect entry has no `platform` field — narrow with `isWalletConnectWallet(wallet)` before reading `wallet.platform`. Per-platform wallet filters (`wallets.filter(w => w.platform === "polkadot")`) no longer match it; find it with `wallets.find(isWalletConnectWallet)`.
-  - Connect/disconnect are session-wide: connecting opens one modal and the wallet approves whichever namespaces it supports; a namespace cannot be added to a live session (disconnect and re-pair to change the approved set).
-
-### Patch Changes
-
-- [`ef02b3a`](https://github.com/kheopskit/kheopskit/commit/ef02b3ade87c04c1732e746f4490b70b94b85451) Thanks [@0xKheops](https://github.com/0xKheops)! - fix: wallet connect ethereum
-
-- Updated dependencies [[`ef02b3a`](https://github.com/kheopskit/kheopskit/commit/ef02b3ade87c04c1732e746f4490b70b94b85451)]:
-  - @kheopskit/core@5.0.0
-
 ## 4.0.0
 
 ### Major Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kheopskit/react",
-	"version": "5.0.0",
+	"version": "4.0.0",
 	"description": "",
 	"private": false,
 	"sideEffects": false,
@@ -43,7 +43,7 @@
 	},
 	"license": "ISC",
 	"peerDependencies": {
-		"@kheopskit/core": "^5.0.0",
+		"@kheopskit/core": "^4.0.0",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0",
 		"rxjs": ">=7.0.0"


### PR DESCRIPTION
## Why

The "Version Packages" PR (#54) is currently set to publish **6.0.0**, but the intended release is **5.0.0** — npm is at **4.0.0** and 5.0.0 was never published.

The WalletConnect multi-platform work ran `changeset version` **on the feature branch** (committing a 5.0.0 version bump + CHANGELOG entries) before merge. With the pending `major` changeset on top, the bot computed `5.0.0 + major = 6.0.0`.

## What

Realign `main`'s committed version back to `4.0.0` so the single changeset drives a clean `4.0.0 → 5.0.0`:

- `version` `5.0.0 → 4.0.0` in root, `@kheopskit/core`, `@kheopskit/react`
- react `peerDependencies["@kheopskit/core"]` `^5.0.0 → ^4.0.0`
- Removed the prematurely-committed `## 5.0.0` CHANGELOG sections (core + react) — they regenerate from `.changeset/major-release-hardening.md` (headlined by the WalletConnect connector)

## Verify

- `changeset status` → all three packages bump to **5.0.0**
- `pnpm install --frozen-lockfile` passes (lockfile unaffected)

After this merges, the changesets bot regenerates #54 as **5.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)