### PR TITLE
👷 add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     # Mirrors `minimumReleaseAge: 4320` in pnpm-workspace.yaml (3 days), so
     # Dependabot never proposes a version pnpm would refuse to install.
     cooldown:
@@ -29,7 +29,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     commit-message:
       prefix: "⬆️ "
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  # pnpm workspace: the root manifest plus packages/* and examples/*
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Mirrors `minimumReleaseAge: 4320` in pnpm-workspace.yaml (3 days), so
+    # Dependabot never proposes a version pnpm would refuse to install.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    commit-message:
+      prefix: "⬆️ "
+    groups:
+      # One PR for everything that stays inside its semver range. Majors are
+      # left ungrouped on purpose: they need review, and the ones in
+      # packages/core `dependencies` also need a changeset.
+      in-range:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "⬆️ "
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,25 @@ updates:
       semver-major-days: 7
     commit-message:
       prefix: "⬆️ "
+    open-pull-requests-limit: 10
     groups:
-      # One PR for everything that stays inside its semver range. Majors are
-      # left ungrouped on purpose: they need review, and the ones in
-      # packages/core `dependencies` also need a changeset.
+      # One PR for the routine minor/patch batch. Majors are left ungrouped on
+      # purpose: they need review, and the ones in packages/core `dependencies`
+      # also need a changeset.
       in-range:
         patterns:
           - "*"
+        # Pre-1.0 packages are excluded: Dependabot classifies by version
+        # segment, so 0.12.2 -> 0.13.0 counts as "minor" even though ^0.12.2
+        # excludes it, and 0.x carries no breakage contract. They get their own
+        # PRs. Dependabot has no "in-range only" selector, so this list is
+        # manual — a new 0.x dependency lands in the batch until added here.
+        exclude-patterns:
+          - "@changesets/changelog-github"
+          - "@solana-program/*"
+          - "class-variance-authority"
+          - "mipd"
+          - "next-themes"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Repo had no `dependabot.yml`, so only security PRs were opening — routine version bumps had to be done by hand.

- npm + github-actions, weekly
- minor/patch grouped into a single PR; majors stay individual for review
- `cooldown: 3 days` mirrors `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`, so proposed versions are always installable
- `⬆️` commit prefix to match repo convention