### PR TITLE
🔧 drop redundant tsconfig options

### DIFF
--- a/examples/vite-react/tsconfig.app.json
+++ b/examples/vite-react/tsconfig.app.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 		"target": "ES2022",
-		"useDefineForClassFields": true,
 		"lib": ["ES2023", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
 		"skipLibCheck": true,

--- a/examples/vite-react/tsconfig.json
+++ b/examples/vite-react/tsconfig.json
@@ -1,12 +1,9 @@
 {
+	// Solution-style config: `files: []` means these compilerOptions would apply to
+	// no files, so `paths` lives in tsconfig.app.json (which includes src/).
 	"files": [],
 	"references": [
 		{ "path": "./tsconfig.app.json" },
 		{ "path": "./tsconfig.node.json" }
-	],
-	"compilerOptions": {
-		"paths": {
-			"@/*": ["./src/*"]
-		}
-	}
+	]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,8 @@
 {
 	"extends": "../../tsconfig.base",
-	"include": ["src", "tests"],
+	"include": ["src"],
 	"compilerOptions": {
 		"composite": true,
-		"declaration": true,
 		"noEmit": true
 	}
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"extends": "../../tsconfig.base",
-	"include": ["src", "tests", "../core/src"],
+	"include": ["src", "../core/src"],
 	"compilerOptions": {
 		"jsx": "react-jsx",
 		"composite": true,
-		"declaration": true,
 		"noEmit": true,
 		"paths": {
 			"@kheopskit/core": ["../core/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,26 +1,20 @@
 {
 	"compilerOptions": {
-		"ignoreDeprecations": "6.0",
 		"target": "ES2022",
 		"module": "ESNext",
 		"lib": ["DOM", "DOM.Iterable", "ES2023"],
-		"skipLibCheck": true,
+		"moduleResolution": "Bundler",
+		"esModuleInterop": true,
 		"importHelpers": true,
-		"declaration": false,
-		"sourceMap": false,
+		"skipLibCheck": true,
+		// `strict` already implies noImplicitAny, strictNullChecks,
+		// strictFunctionTypes, strictPropertyInitialization, noImplicitThis and
+		// alwaysStrict, so those are not restated here.
 		"strict": true,
-		"noImplicitAny": true,
-		"strictNullChecks": true,
-		"strictFunctionTypes": true,
-		"strictPropertyInitialization": true,
-		"noImplicitThis": true,
-		"alwaysStrict": true,
+		"noUncheckedIndexedAccess": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true,
-		"moduleResolution": "Bundler",
-		"esModuleInterop": true,
-		"noUncheckedIndexedAccess": true
+		"noFallthroughCasesInSwitch": true
 	}
 }


### PR DESCRIPTION
Removes options that were already in effect. Stacked on #77, since "is this the default?" depends on the TypeScript version — every claim below was verified against TS 7 rather than assumed.

**tsconfig.base.json**
- `noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict` — all implied by `strict: true`
- `declaration: false`, `sourceMap: false` — already the defaults
- `ignoreDeprecations: "6.0"` — nothing in the configs is deprecated under TS 7 anymore

**packages/core + packages/react tsconfig.json**
- `declaration: true` — implied by `composite: true`, and irrelevant anyway under `noEmit: true`. Both `tsconfig.build.json` files set it explicitly (they use `composite: false`), so emit is unaffected.
- `"tests"` dropped from `include` — neither `packages/core/tests` nor `packages/react/tests` exists; tests live beside sources as `*.test.ts`.

**examples/vite-react**
- `useDefineForClassFields: true` in `tsconfig.app.json` — already the default at `target: ES2022`
- `compilerOptions.paths` in `tsconfig.json` — that file is solution-style (`files: []`), so its options applied to no files; `tsconfig.app.json` already declares the same `paths`

## Verification

Removing strictness flags is the risky part, so it's proven rather than argued — a temporary file in `packages/core/src` still produces all three errors under the cleaned config:

```
TS7006  Parameter 'x' implicitly has an 'any' type.
TS18047 's' is possibly 'null'.
TS2564  Property 'p' has no initializer and is not definitely assigned in the constructor.
```

`useDefineForClassFields` was confirmed default-on by `TS2610` firing at `target: ES2022` with no flag set. The `@/*` alias still resolves — `vite-tsconfig-paths` reads the config that includes the file, and vite-react builds.

**Deliberately kept:** `moduleResolution: "Bundler"` is *not* the default for `module: ESNext` — without it TS 7 fails with `TS2307 Cannot find module '@scure/base'`. Also kept `esModuleInterop`, `importHelpers`, `skipLibCheck` and the `noUnused*`/`noUncheckedIndexedAccess` family, none of which are defaults.

Full CI sequence green locally: `check`, `typecheck` (5/5), `build:packages`, `knip`, `check:isolation` (16/16), `test` (359/359), `build:examples` (all 3).