### PR TITLE
⬆️ @testing-library/jest-dom 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@changesets/cli": "^2.31.1",
 		"@playwright/test": "^1.61.1",
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/jest-dom": "^7.0.0",
 		"@testing-library/react": "^16.3.2",
 		"happy-dom": "^20.11.0",
 		"jsdom": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^10.4.1
         version: 10.4.1
       '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.10.0(@testing-library/dom@10.4.1)
+        specifier: ^7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3341,10 +3341,9 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
-  '@testing-library/jest-dom@6.10.0':
-    resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
+  '@testing-library/jest-dom@7.0.0':
+    resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
     engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
-    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
     peerDependencies:
       '@testing-library/dom': '>=10 <11'
 
@@ -11578,7 +11577,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1)':
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
     dependencies:
       '@adobe/css-tools': 4.5.0
       '@testing-library/dom': 10.4.1


### PR DESCRIPTION
The spec was `^6.9.1`, but the caret resolved to **6.10.0** — which is deprecated:

> Incorrect minor release with breaking changes (Node >=22 and required `@testing-library/dom` peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.

6.10.0 was published three minutes before 7.0.0, so it was a mis-release of 7.0.0's content onto the 6.x line. Pinning back to `6.9.1` would mean staying on an October 2025 release, and both of 7.0.0's requirements are already satisfied here:

| requirement | 7.0.0 wants | repo has |
|---|---|---|
| `@testing-library/dom` peer | `>=10 <11` | `^10.4.1` |
| node | `>=22` | 24 (`engines: >=24`) |
| `./vitest` subpath | present | used by `vitest.setup.ts` |

Root devDependency only, so no changeset.

Verified: 359/359 tests including the 32 jest-dom matcher assertions in `packages/react` (`toHaveTextContent`, `toBeInTheDocument`), the `/// <reference types="@testing-library/jest-dom" />` references still resolve under typecheck, and the jest-dom deprecation warning is gone from install output.