### PR TITLE
✨ require a changeset for every change that reaches a published package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,23 @@ updates:
         update-types:
           - "version-update:semver-major"
     groups:
+      # Listed first because a dependency joins the first group it matches.
+      #
+      # These are packages/core's `dependencies` — the only deps that ship in a
+      # published manifest, so bumping them always needs a changeset and a
+      # release. Split out of the in-range batch so that changeset rides on a
+      # small, obvious PR instead of alongside five unrelated devDep bumps.
+      # The list is manual (Dependabot has no "production deps of publishable
+      # workspaces" selector, and `dependency-type: production` would also
+      # scoop up every examples/* runtime dep). Forgetting to extend it is not
+      # a correctness problem: `pnpm check:changeset` gates on the diff, not on
+      # this list, so a new core dependency is still caught.
+      runtime:
+        patterns:
+          - "@noble/hashes"
+          - "@scure/base"
+          - "lodash-es"
+
       # One PR for the routine minor/patch batch. Majors are left ungrouped on
       # purpose: they need review, and the ones in packages/core `dependencies`
       # also need a changeset.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,12 @@ jobs:
       # everything above, yet can never satisfy the gate — it rewrites
       # peerDependencies through `sync-peer-deps` while deleting the changesets
       # it consumed.
+      #
+      # The exemption also checks the head repo, because `head_ref` is just a
+      # branch name the PR author picks: a fork could otherwise call its branch
+      # `changeset-release/main` and skip the gate entirely.
       - name: Changeset
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && !(github.head_ref == 'changeset-release/main' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}"
           BASE_REF="origin/${{ github.base_ref }}" pnpm check:changeset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,38 +6,16 @@ on:
       - main
 
 jobs:
-  # Runs standalone rather than inside `checks`: it needs no install or build,
-  # so a forgotten changeset surfaces in seconds instead of behind the e2e
-  # suite, and a failure here never masks real lint/test signal.
-  changeset:
-    name: Changeset
-    # The release PR rewrites peerDependencies through `sync-peer-deps` while
-    # deleting the changesets it consumed, so the gate can never pass on it.
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          # `git show <base>:<path>` and the three-dot diff both need history
-          # past the PR head that the default shallow clone leaves out.
+          # The changeset gate reads `git show <base>:<path>` and diffs
+          # three-dot against the base, neither of which the default shallow
+          # clone has the history for.
           fetch-depth: 0
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-      # Invoked as `node`, not `pnpm check:changeset`: pnpm verifies the
-      # dependency graph before running a script, which drags in a full install
-      # plus the `papi` postinstall for a check that is only git plumbing over
-      # package.json. The pnpm script stays for local runs.
-      - name: Require a changeset for published dependency changes
-        run: |
-          git fetch --no-tags origin "${{ github.base_ref }}"
-          BASE_REF="origin/${{ github.base_ref }}" node scripts/check-changeset-needed.mjs
-
-  checks:
-    name: Lint, typecheck and unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -57,6 +35,19 @@ jobs:
         run: pnpm typecheck
       - name: Unit tests
         run: pnpm test
+      # Last, so the real signal above lands first — but `!cancelled()` instead
+      # of the default `success()`, otherwise a lint failure hides a missing
+      # changeset and you discover it only on the next push.
+      #
+      # Gated at the step rather than the job: the release PR must still run
+      # everything above, yet can never satisfy the gate — it rewrites
+      # peerDependencies through `sync-peer-deps` while deleting the changesets
+      # it consumed.
+      - name: Changeset
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' }}
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          BASE_REF="origin/${{ github.base_ref }}" pnpm check:changeset
 
   e2e:
     name: E2E (production builds, mock wallets)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,32 @@ on:
       - main
 
 jobs:
+  # Runs standalone rather than inside `checks`: it needs no install or build,
+  # so a forgotten changeset surfaces in seconds instead of behind the e2e
+  # suite, and a failure here never masks real lint/test signal.
+  changeset:
+    name: Changeset
+    # The release PR rewrites peerDependencies through `sync-peer-deps` while
+    # deleting the changesets it consumed, so the gate can never pass on it.
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # `git show <base>:<path>` and the three-dot diff both need history
+          # past the PR head that the default shallow clone leaves out.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      # No install: the gate is plain git plumbing over package.json, so it
+      # skips the dependency graph entirely.
+      - name: Require a changeset for published dependency changes
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          BASE_REF="origin/${{ github.base_ref }}" pnpm check:changeset
+
   checks:
     name: Lint, typecheck and unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,17 @@ jobs:
           # `git show <base>:<path>` and the three-dot diff both need history
           # past the PR head that the default shallow clone leaves out.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-      # No install: the gate is plain git plumbing over package.json, so it
-      # skips the dependency graph entirely.
+      # Invoked as `node`, not `pnpm check:changeset`: pnpm verifies the
+      # dependency graph before running a script, which drags in a full install
+      # plus the `papi` postinstall for a check that is only git plumbing over
+      # package.json. The pnpm script stays for local runs.
       - name: Require a changeset for published dependency changes
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}"
-          BASE_REF="origin/${{ github.base_ref }}" pnpm check:changeset
+          BASE_REF="origin/${{ github.base_ref }}" node scripts/check-changeset-needed.mjs
 
   checks:
     name: Lint, typecheck and unit tests

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"changeset-release-pr": "changeset version && pnpm sync-peer-deps && pnpm install && pnpm build:packages",
 		"check": "pnpm biome check --error-on-warnings .",
 		"check:isolation": "node scripts/check-bundle-isolation.mjs",
+		"check:changeset": "node scripts/check-changeset-needed.mjs",
 		"typecheck": "pnpm -r --parallel typecheck",
 		"knip": "knip --treat-config-hints-as-errors --treat-tag-hints-as-errors"
 	},

--- a/scripts/check-changeset-needed.mjs
+++ b/scripts/check-changeset-needed.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Fails a pull request that changes a published package's `dependencies` or
+ * `peerDependencies` without adding a changeset.
+ *
+ * Those two fields are the only part of a dependency bump that reaches npm
+ * consumers: they ship verbatim in the published manifest and dictate what
+ * gets installed alongside our packages. Everything else a Dependabot PR
+ * usually touches — devDependencies, the lockfile, examples, workflows — leaves
+ * the published artifact byte-identical, so requiring a changeset there would
+ * fail nearly every PR and train everyone to bypass the gate.
+ *
+ * The check keys off the diff rather than the PR author or the Dependabot
+ * group name, so a dependency added to `packages/core` later is covered without
+ * touching any config.
+ *
+ * It only asserts that *a* changeset was added, not which package it names:
+ * the `fixed` group in .changeset/config.json versions kheopskit,
+ * @kheopskit/core and @kheopskit/react in lockstep, so any changeset bumps all
+ * three anyway.
+ *
+ * Run on pull requests only, and skip the changesets release PR — it rewrites
+ * peerDependencies via `sync-peer-deps` while deleting the changesets it
+ * consumed.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const BASE = process.env.BASE_REF ?? "origin/main";
+const PUBLISHED = ["packages/core/package.json", "packages/react/package.json"];
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf-8" });
+
+/** Dependency fields of `path`, at `ref` or on disk when `ref` is null. */
+const fieldsAt = (ref, path) => {
+	let raw;
+	try {
+		raw =
+			ref === null
+				? readFileSync(path, "utf-8")
+				: git("show", `${ref}:${path}`);
+	} catch {
+		// Absent at this ref (new package, or deleted) — treat as a change.
+		return null;
+	}
+	const pkg = JSON.parse(raw);
+	return JSON.stringify({
+		dependencies: pkg.dependencies ?? {},
+		peerDependencies: pkg.peerDependencies ?? {},
+	});
+};
+
+const affected = PUBLISHED.filter((path) => {
+	const before = fieldsAt(BASE, path);
+	const after = fieldsAt(null, path);
+	return before === null || after === null || before !== after;
+});
+
+if (affected.length === 0) {
+	console.log(
+		"No published dependency ranges changed — no changeset required.",
+	);
+	process.exit(0);
+}
+
+const isChangeset = (file) =>
+	file.startsWith(".changeset/") && file.endsWith(".md");
+
+// Committed on this branch, plus anything still untracked so a local run
+// matches the working-tree manifests it just compared against. CI only ever
+// sees the committed set.
+const addedChangesets = [
+	...git("diff", "--name-only", "--diff-filter=A", `${BASE}...HEAD`).split(
+		"\n",
+	),
+	...git("ls-files", "--others", "--exclude-standard", ".changeset").split(
+		"\n",
+	),
+].filter(isChangeset);
+
+if (addedChangesets.length > 0) {
+	console.log(
+		`Published dependency ranges changed in ${affected.join(", ")}, covered by ${addedChangesets.join(", ")}.`,
+	);
+	process.exit(0);
+}
+
+console.error(
+	[
+		"Missing changeset.",
+		"",
+		"These published manifests changed their dependency ranges, so npm",
+		"consumers get something different and the change needs a release:",
+		...affected.map((path) => `  - ${path}`),
+		"",
+		'Run `pnpm changeset` and include the root "kheopskit" package in the',
+		"selection — the fixed group needs it or the release tag reuses the",
+		"previous version.",
+	].join("\n"),
+);
+process.exit(1);

--- a/scripts/check-changeset-needed.mjs
+++ b/scripts/check-changeset-needed.mjs
@@ -1,17 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * Fails a pull request that changes what npm consumers install from a
- * published package without adding a changeset that actually releases it.
+ * Fails a pull request that changes a published package without adding a
+ * changeset that actually releases it.
  *
- * Only the dependency-related manifest fields are compared. They ship verbatim
- * to npm and dictate the install contract; everything else a dependency PR
- * usually touches — devDependencies, the lockfile, examples, workflows — leaves
- * the published artifact byte-identical. Requiring a changeset there would fail
- * nearly every PR and train everyone to bypass the gate.
+ * "Changes a published package" means anything that alters what npm consumers
+ * would get: the source that `dist` is built from, the files listed in `files`,
+ * the build configuration, and the manifest itself. Two manifest fields are
+ * deliberately excluded:
+ *
+ *   - `version`, which Changesets owns.
+ *   - `devDependencies`, which npm publishes but never installs for consumers.
+ *     Requiring a changeset for every Dependabot devDep bump is the failure
+ *     mode this gate exists to avoid: a check that fails on nearly every PR is
+ *     one everybody learns to bypass. This holds only while no devDep-only
+ *     package reaches the build output — today every such import in
+ *     packages/core is `import type` and none appear in the emitted `.d.ts`, so
+ *     a bump cannot change a published byte. A future *value* import of a
+ *     devDep would be bundled into `dist` and would break that assumption.
+ *
+ * Everything else a dependency PR usually touches — the lockfile, examples,
+ * workflows, tests — leaves the published artifact byte-identical.
  *
  * The check keys off the diff rather than the PR author or the Dependabot
- * group name, so a dependency added to `packages/core` later is covered without
+ * group name, so a package or dependency added later is covered without
  * touching any config.
  *
  * Coverage is decided by Changesets itself rather than by looking at filenames:
@@ -19,8 +31,8 @@
  * file, an `--empty` changeset, or one naming only an ignored example is
  * correctly seen as releasing nothing. The gate additionally requires the
  * release to be driven by a changeset *this branch added*, so an unrelated
- * changeset already sitting on main cannot silently cover a new dependency
- * change that would then ship with no changelog entry.
+ * changeset already sitting on the base branch cannot silently cover a change
+ * that would then ship with no changelog entry.
  *
  * Run on pull requests only, and skip the Changesets release PR — it rewrites
  * peerDependencies via `sync-peer-deps` while deleting the changesets it
@@ -32,27 +44,26 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 const BASE = process.env.BASE_REF ?? "origin/main";
-const PUBLISHED = ["packages/core/package.json", "packages/react/package.json"];
+const PACKAGES = ["packages/core", "packages/react"];
+
+/** Owned by Changesets, or published but inert for consumers. */
+const UNPUBLISHED_FIELDS = ["version", "devDependencies"];
 
 /**
- * Every manifest field npm reads when deciding what to install alongside the
- * package. `peerDependenciesMeta` earns its place: dropping an `optional: true`
- * turns a peer into a hard install requirement without any version range
- * changing. The rest are absent today but would ship the moment they appear.
+ * Tracked under a published package, yet cannot reach the npm tarball:
+ * CHANGELOG.md is written by Changesets during the release itself, tests are
+ * never built into `dist`, and the tsbuildinfo is a local build cache.
  */
-const DEPENDENCY_FIELDS = [
-	"dependencies",
-	"peerDependencies",
-	"peerDependenciesMeta",
-	"optionalDependencies",
-	"bundledDependencies",
-	"bundleDependencies",
+const IRRELEVANT = [
+	/(^|\/)CHANGELOG\.md$/,
+	/\.test\.[cm]?tsx?$/,
+	/(^|\/)tsconfig\.tsbuildinfo$/,
 ];
 
 /**
- * Key order in package.json and entry order in `bundledDependencies` carry no
- * meaning to npm, so normalise both before comparing — a reformat must not read
- * as a dependency change.
+ * Key order in package.json and entry order in fields like
+ * `bundledDependencies` carry no meaning to npm, so normalise both before
+ * comparing — a reformat must not read as a real change.
  */
 const stable = (value) => {
 	if (Array.isArray(value))
@@ -67,17 +78,32 @@ const stable = (value) => {
 	);
 };
 
-/** The part of a manifest that changes what consumers install. */
-export const dependencyContract = (pkg) =>
+/**
+ * The part of a manifest that consumers can observe. Comparing everything but
+ * the two excluded fields means new fields are covered by default — `exports`,
+ * `files`, `engines` and the `tsdown` build config all change the published
+ * package, and none of them need to be enumerated here to be caught.
+ */
+export const publishedManifest = (pkg) =>
 	JSON.stringify(
 		stable(
 			Object.fromEntries(
-				DEPENDENCY_FIELDS.filter((field) => pkg[field] !== undefined).map(
-					(field) => [field, pkg[field]],
+				Object.entries(pkg).filter(
+					([field]) => !UNPUBLISHED_FIELDS.includes(field),
 				),
 			),
 		),
 	);
+
+/**
+ * Whether a changed path feeds the published artifact. package.json is
+ * excluded because it is compared field-wise instead — a devDependency bump
+ * shows up as a changed file but not as a changed package.
+ */
+export const affectsPublishedArtifact = (file) =>
+	PACKAGES.some((dir) => file.startsWith(`${dir}/`)) &&
+	!file.endsWith("/package.json") &&
+	!IRRELEVANT.some((pattern) => pattern.test(file));
 
 /**
  * Given a Changesets release plan, the ids of changesets that drive a real
@@ -94,9 +120,10 @@ export const planCoverage = (plan, publishedNames) => {
 };
 
 const git = (...args) => execFileSync("git", args, { encoding: "utf-8" });
+const lines = (out) => out.split("\n").filter(Boolean);
 
-/** Dependency contract of `path`, at `ref` or on disk when `ref` is null. */
-const contractAt = (ref, path) => {
+/** Published manifest at `ref`, or from disk when `ref` is null. */
+const manifestAt = (ref, path) => {
 	let raw;
 	try {
 		raw =
@@ -107,7 +134,7 @@ const contractAt = (ref, path) => {
 		// Absent at this ref (new package, or deleted) — treat as a change.
 		return null;
 	}
-	return dependencyContract(JSON.parse(raw));
+	return publishedManifest(JSON.parse(raw));
 };
 
 /**
@@ -128,52 +155,47 @@ const releasePlan = () => {
 	}
 };
 
-const fail = (lines) => {
-	console.error(lines.join("\n"));
+const fail = (message) => {
+	console.error(message.join("\n"));
 	process.exit(1);
 };
 
 const main = () => {
-	const affected = PUBLISHED.filter((path) => {
-		const before = contractAt(BASE, path);
-		const after = contractAt(null, path);
-		return before === null || after === null || before !== after;
-	});
+	// Everything this branch changed, including work not yet committed, against
+	// the point it diverged — so a base branch that moved on cannot make an
+	// unrelated PR look like it touched a published package.
+	const since = git("merge-base", BASE, "HEAD").trim();
+	const changed = [
+		...lines(git("diff", "--name-only", since)),
+		...lines(git("ls-files", "--others", "--exclude-standard")),
+	];
+
+	const affected = [
+		...PACKAGES.map((dir) => `${dir}/package.json`).filter((path) => {
+			const before = manifestAt(since, path);
+			const after = manifestAt(null, path);
+			return before === null || after === null || before !== after;
+		}),
+		...changed.filter(affectsPublishedArtifact),
+	].sort();
 
 	if (affected.length === 0) {
-		console.log(
-			"No published dependency contract changed — no changeset required.",
-		);
+		console.log("No published package changed — no changeset required.");
 		return;
 	}
 
-	const publishedNames = PUBLISHED.map(
-		(path) => JSON.parse(readFileSync(path, "utf-8")).name,
+	const publishedNames = PACKAGES.map(
+		(dir) => JSON.parse(readFileSync(`${dir}/package.json`, "utf-8")).name,
 	);
-	const addedIds = git(
-		"diff",
-		"--name-only",
-		"--diff-filter=A",
-		`${BASE}...HEAD`,
-	)
-		.split("\n")
-		// Untracked too, so a local run matches the working-tree manifests it
-		// just compared against. CI only ever sees the committed set.
-		.concat(
-			git("ls-files", "--others", "--exclude-standard", ".changeset").split(
-				"\n",
-			),
-		)
+	const addedIds = changed
 		.filter((file) => file.startsWith(".changeset/") && file.endsWith(".md"))
 		.map((file) => basename(file, ".md"));
 
 	const { plan, error } = releasePlan();
 	const { releasesPublished, drivingIds } = planCoverage(plan, publishedNames);
-	const covered = addedIds.some((id) => drivingIds.has(id));
 
 	const why = [
-		"These published manifests changed what consumers install, so the change",
-		"needs a release:",
+		"These changes reach the published packages, so they need a release:",
 		...affected.map((path) => `  - ${path}`),
 		"",
 	];
@@ -186,21 +208,21 @@ const main = () => {
 			'Run `pnpm changeset` and include the root "kheopskit" package in the',
 			"selection — the fixed group needs it or the release tag reuses the",
 			"previous version.",
-			...(error ? ["", `changeset status said:`, error] : []),
+			...(error ? ["", "changeset status said:", error] : []),
 		]);
 
-	if (!covered)
+	if (!addedIds.some((id) => drivingIds.has(id)))
 		return fail([
 			"Missing changeset on this branch.",
 			"",
 			...why,
 			"A changeset already on the base branch would release these packages,",
-			"but this branch adds none — the dependency change would ship with no",
-			"changelog entry of its own. Run `pnpm changeset`.",
+			"but this branch adds none — the change would ship with no changelog",
+			"entry of its own. Run `pnpm changeset`.",
 		]);
 
 	console.log(
-		`Published dependency contract changed in ${affected.join(", ")}, released by ${addedIds.filter((id) => drivingIds.has(id)).join(", ")}.`,
+		`${affected.length} published change(s), released by ${addedIds.filter((id) => drivingIds.has(id)).join(", ")}.`,
 	);
 };
 

--- a/scripts/check-changeset-needed.mjs
+++ b/scripts/check-changeset-needed.mjs
@@ -1,39 +1,102 @@
 #!/usr/bin/env node
 
 /**
- * Fails a pull request that changes a published package's `dependencies` or
- * `peerDependencies` without adding a changeset.
+ * Fails a pull request that changes what npm consumers install from a
+ * published package without adding a changeset that actually releases it.
  *
- * Those two fields are the only part of a dependency bump that reaches npm
- * consumers: they ship verbatim in the published manifest and dictate what
- * gets installed alongside our packages. Everything else a Dependabot PR
+ * Only the dependency-related manifest fields are compared. They ship verbatim
+ * to npm and dictate the install contract; everything else a dependency PR
  * usually touches — devDependencies, the lockfile, examples, workflows — leaves
- * the published artifact byte-identical, so requiring a changeset there would
- * fail nearly every PR and train everyone to bypass the gate.
+ * the published artifact byte-identical. Requiring a changeset there would fail
+ * nearly every PR and train everyone to bypass the gate.
  *
  * The check keys off the diff rather than the PR author or the Dependabot
  * group name, so a dependency added to `packages/core` later is covered without
  * touching any config.
  *
- * It only asserts that *a* changeset was added, not which package it names:
- * the `fixed` group in .changeset/config.json versions kheopskit,
- * @kheopskit/core and @kheopskit/react in lockstep, so any changeset bumps all
- * three anyway.
+ * Coverage is decided by Changesets itself rather than by looking at filenames:
+ * `changeset status` applies the real ignore/fixed rules, so a dot-prefixed
+ * file, an `--empty` changeset, or one naming only an ignored example is
+ * correctly seen as releasing nothing. The gate additionally requires the
+ * release to be driven by a changeset *this branch added*, so an unrelated
+ * changeset already sitting on main cannot silently cover a new dependency
+ * change that would then ship with no changelog entry.
  *
- * Run on pull requests only, and skip the changesets release PR — it rewrites
+ * Run on pull requests only, and skip the Changesets release PR — it rewrites
  * peerDependencies via `sync-peer-deps` while deleting the changesets it
  * consumed.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 
 const BASE = process.env.BASE_REF ?? "origin/main";
 const PUBLISHED = ["packages/core/package.json", "packages/react/package.json"];
 
+/**
+ * Every manifest field npm reads when deciding what to install alongside the
+ * package. `peerDependenciesMeta` earns its place: dropping an `optional: true`
+ * turns a peer into a hard install requirement without any version range
+ * changing. The rest are absent today but would ship the moment they appear.
+ */
+const DEPENDENCY_FIELDS = [
+	"dependencies",
+	"peerDependencies",
+	"peerDependenciesMeta",
+	"optionalDependencies",
+	"bundledDependencies",
+	"bundleDependencies",
+];
+
+/**
+ * Key order in package.json and entry order in `bundledDependencies` carry no
+ * meaning to npm, so normalise both before comparing — a reformat must not read
+ * as a dependency change.
+ */
+const stable = (value) => {
+	if (Array.isArray(value))
+		return value
+			.map(stable)
+			.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+	if (value === null || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.keys(value)
+			.sort()
+			.map((key) => [key, stable(value[key])]),
+	);
+};
+
+/** The part of a manifest that changes what consumers install. */
+export const dependencyContract = (pkg) =>
+	JSON.stringify(
+		stable(
+			Object.fromEntries(
+				DEPENDENCY_FIELDS.filter((field) => pkg[field] !== undefined).map(
+					(field) => [field, pkg[field]],
+				),
+			),
+		),
+	);
+
+/**
+ * Given a Changesets release plan, the ids of changesets that drive a real
+ * release, and whether the published packages are among what gets released.
+ * Ignored packages surface as `type: "none"`, so filtering on that is what
+ * makes an example-only changeset correctly count for nothing.
+ */
+export const planCoverage = (plan, publishedNames) => {
+	const releasing = (plan?.releases ?? []).filter((r) => r.type !== "none");
+	return {
+		releasesPublished: releasing.some((r) => publishedNames.includes(r.name)),
+		drivingIds: new Set(releasing.flatMap((r) => r.changesets ?? [])),
+	};
+};
+
 const git = (...args) => execFileSync("git", args, { encoding: "utf-8" });
 
-/** Dependency fields of `path`, at `ref` or on disk when `ref` is null. */
-const fieldsAt = (ref, path) => {
+/** Dependency contract of `path`, at `ref` or on disk when `ref` is null. */
+const contractAt = (ref, path) => {
 	let raw;
 	try {
 		raw =
@@ -44,59 +107,101 @@ const fieldsAt = (ref, path) => {
 		// Absent at this ref (new package, or deleted) — treat as a change.
 		return null;
 	}
-	const pkg = JSON.parse(raw);
-	return JSON.stringify({
-		dependencies: pkg.dependencies ?? {},
-		peerDependencies: pkg.peerDependencies ?? {},
-	});
+	return dependencyContract(JSON.parse(raw));
 };
 
-const affected = PUBLISHED.filter((path) => {
-	const before = fieldsAt(BASE, path);
-	const after = fieldsAt(null, path);
-	return before === null || after === null || before !== after;
-});
+/**
+ * The release plan Changesets would produce right now, or null when it refuses
+ * to produce one — which is what happens when nothing here releases anything.
+ * Its stderr is surfaced on failure so a genuine tooling break is diagnosable
+ * rather than being reported as a missing changeset.
+ */
+const releasePlan = () => {
+	const out = join(mkdtempSync(join(tmpdir(), "changeset-gate-")), "plan.json");
+	try {
+		execFileSync("node_modules/.bin/changeset", ["status", "--output", out], {
+			stdio: "pipe",
+		});
+		return { plan: JSON.parse(readFileSync(out, "utf-8")), error: null };
+	} catch (cause) {
+		return { plan: null, error: String(cause.stderr ?? cause.message).trim() };
+	}
+};
 
-if (affected.length === 0) {
-	console.log(
-		"No published dependency ranges changed — no changeset required.",
+const fail = (lines) => {
+	console.error(lines.join("\n"));
+	process.exit(1);
+};
+
+const main = () => {
+	const affected = PUBLISHED.filter((path) => {
+		const before = contractAt(BASE, path);
+		const after = contractAt(null, path);
+		return before === null || after === null || before !== after;
+	});
+
+	if (affected.length === 0) {
+		console.log(
+			"No published dependency contract changed — no changeset required.",
+		);
+		return;
+	}
+
+	const publishedNames = PUBLISHED.map(
+		(path) => JSON.parse(readFileSync(path, "utf-8")).name,
 	);
-	process.exit(0);
-}
+	const addedIds = git(
+		"diff",
+		"--name-only",
+		"--diff-filter=A",
+		`${BASE}...HEAD`,
+	)
+		.split("\n")
+		// Untracked too, so a local run matches the working-tree manifests it
+		// just compared against. CI only ever sees the committed set.
+		.concat(
+			git("ls-files", "--others", "--exclude-standard", ".changeset").split(
+				"\n",
+			),
+		)
+		.filter((file) => file.startsWith(".changeset/") && file.endsWith(".md"))
+		.map((file) => basename(file, ".md"));
 
-const isChangeset = (file) =>
-	file.startsWith(".changeset/") && file.endsWith(".md");
+	const { plan, error } = releasePlan();
+	const { releasesPublished, drivingIds } = planCoverage(plan, publishedNames);
+	const covered = addedIds.some((id) => drivingIds.has(id));
 
-// Committed on this branch, plus anything still untracked so a local run
-// matches the working-tree manifests it just compared against. CI only ever
-// sees the committed set.
-const addedChangesets = [
-	...git("diff", "--name-only", "--diff-filter=A", `${BASE}...HEAD`).split(
-		"\n",
-	),
-	...git("ls-files", "--others", "--exclude-standard", ".changeset").split(
-		"\n",
-	),
-].filter(isChangeset);
-
-if (addedChangesets.length > 0) {
-	console.log(
-		`Published dependency ranges changed in ${affected.join(", ")}, covered by ${addedChangesets.join(", ")}.`,
-	);
-	process.exit(0);
-}
-
-console.error(
-	[
-		"Missing changeset.",
-		"",
-		"These published manifests changed their dependency ranges, so npm",
-		"consumers get something different and the change needs a release:",
+	const why = [
+		"These published manifests changed what consumers install, so the change",
+		"needs a release:",
 		...affected.map((path) => `  - ${path}`),
 		"",
-		'Run `pnpm changeset` and include the root "kheopskit" package in the',
-		"selection — the fixed group needs it or the release tag reuses the",
-		"previous version.",
-	].join("\n"),
-);
-process.exit(1);
+	];
+
+	if (!releasesPublished)
+		return fail([
+			"Missing changeset.",
+			"",
+			...why,
+			'Run `pnpm changeset` and include the root "kheopskit" package in the',
+			"selection — the fixed group needs it or the release tag reuses the",
+			"previous version.",
+			...(error ? ["", `changeset status said:`, error] : []),
+		]);
+
+	if (!covered)
+		return fail([
+			"Missing changeset on this branch.",
+			"",
+			...why,
+			"A changeset already on the base branch would release these packages,",
+			"but this branch adds none — the dependency change would ship with no",
+			"changelog entry of its own. Run `pnpm changeset`.",
+		]);
+
+	console.log(
+		`Published dependency contract changed in ${affected.join(", ")}, released by ${addedIds.filter((id) => drivingIds.has(id)).join(", ")}.`,
+	);
+};
+
+if (import.meta.main) main();

--- a/scripts/check-changeset-needed.mjs
+++ b/scripts/check-changeset-needed.mjs
@@ -6,8 +6,8 @@
  *
  * "Changes a published package" means anything that alters what npm consumers
  * would get: the source that `dist` is built from, the files listed in `files`,
- * the build configuration, and the manifest itself. Two manifest fields are
- * deliberately excluded:
+ * the build configuration — including the shared one at the repository root —
+ * and the manifest itself. Two manifest fields are deliberately excluded:
  *
  *   - `version`, which Changesets owns.
  *   - `devDependencies`, which npm publishes but never installs for consumers.
@@ -23,8 +23,9 @@
  * workflows, tests — leaves the published artifact byte-identical.
  *
  * The check keys off the diff rather than the PR author or the Dependabot
- * group name, so a package or dependency added later is covered without
- * touching any config.
+ * group name, so a dependency added later is covered without touching any
+ * config. A new published package is the one exception: it must be added to
+ * `PACKAGES` below, or the gate never sees it.
  *
  * Coverage is decided by Changesets itself rather than by looking at filenames:
  * `changeset status` applies the real ignore/fixed rules, so a dot-prefixed
@@ -46,8 +47,34 @@ import { basename, join } from "node:path";
 const BASE = process.env.BASE_REF ?? "origin/main";
 const PACKAGES = ["packages/core", "packages/react"];
 
+/**
+ * Build inputs that live outside the packages yet reach their output: both
+ * `tsconfig.build.json` files extend this one, so a `target` or `importHelpers`
+ * change here rewrites the emitted JavaScript and `.d.ts` of packages whose own
+ * files never moved.
+ *
+ * The lockfile is deliberately absent: tsdown externalises `dependencies` and
+ * `peerDependencies`, so a resolution change cannot alter a published byte, and
+ * a gate that fires on every dependency PR is one everybody learns to bypass.
+ * This knowingly waves through toolchain bumps — a new `typescript` or `tsdown`
+ * resolution rewrites the emitted `dist` and `.d.ts` even though no gated file
+ * moved. Accepted: gating the lockfile would reintroduce the fires-on-every-PR
+ * failure mode for a class of change that is cosmetic in practice.
+ * The per-package tsdown config needs no entry either — it lives in the
+ * manifest, which is compared in full.
+ */
+const SHARED_BUILD_INPUTS = ["tsconfig.base.json"];
+
 /** Owned by Changesets, or published but inert for consumers. */
 const UNPUBLISHED_FIELDS = ["version", "devDependencies"];
+
+/**
+ * Fields whose nesting is order-sensitive. Node walks `exports` and `imports`
+ * in declaration order and takes the first condition that matches, so moving
+ * `default` above `types` changes what consumers resolve while every key and
+ * value stays the same.
+ */
+const ORDERED_FIELDS = ["exports", "imports"];
 
 /**
  * Tracked under a published package, yet cannot reach the npm tarball:
@@ -61,20 +88,18 @@ const IRRELEVANT = [
 ];
 
 /**
- * Key order in package.json and entry order in fields like
- * `bundledDependencies` carry no meaning to npm, so normalise both before
- * comparing — a reformat must not read as a real change.
+ * Key order carries no meaning to npm, so a reformat must not read as a real
+ * change. Arrays are left alone: `files` and `keywords` are unordered in
+ * practice but rarely shuffled, whereas an `exports` fallback array is strictly
+ * ordered — sorting would buy nothing and hide a real change.
  */
-const stable = (value) => {
-	if (Array.isArray(value))
-		return value
-			.map(stable)
-			.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+const sortKeys = (value) => {
+	if (Array.isArray(value)) return value.map(sortKeys);
 	if (value === null || typeof value !== "object") return value;
 	return Object.fromEntries(
 		Object.keys(value)
 			.sort()
-			.map((key) => [key, stable(value[key])]),
+			.map((key) => [key, sortKeys(value[key])]),
 	);
 };
 
@@ -86,12 +111,14 @@ const stable = (value) => {
  */
 export const publishedManifest = (pkg) =>
 	JSON.stringify(
-		stable(
-			Object.fromEntries(
-				Object.entries(pkg).filter(
-					([field]) => !UNPUBLISHED_FIELDS.includes(field),
-				),
-			),
+		Object.fromEntries(
+			Object.entries(pkg)
+				.filter(([field]) => !UNPUBLISHED_FIELDS.includes(field))
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([field, value]) => [
+					field,
+					ORDERED_FIELDS.includes(field) ? value : sortKeys(value),
+				]),
 		),
 	);
 
@@ -101,9 +128,10 @@ export const publishedManifest = (pkg) =>
  * shows up as a changed file but not as a changed package.
  */
 export const affectsPublishedArtifact = (file) =>
-	PACKAGES.some((dir) => file.startsWith(`${dir}/`)) &&
-	!file.endsWith("/package.json") &&
-	!IRRELEVANT.some((pattern) => pattern.test(file));
+	SHARED_BUILD_INPUTS.includes(file) ||
+	(PACKAGES.some((dir) => file.startsWith(`${dir}/`)) &&
+		!file.endsWith("/package.json") &&
+		!IRRELEVANT.some((pattern) => pattern.test(file)));
 
 /**
  * Given a Changesets release plan, the ids of changesets that drive a real
@@ -145,10 +173,17 @@ const manifestAt = (ref, path) => {
  */
 const releasePlan = () => {
 	const out = join(mkdtempSync(join(tmpdir(), "changeset-gate-")), "plan.json");
+	// Resolved against this file rather than the cwd, so the gate can be pointed
+	// at another checkout — which is how the provenance tests drive it.
+	const bin = join(
+		import.meta.dirname,
+		"..",
+		"node_modules",
+		".bin",
+		"changeset",
+	);
 	try {
-		execFileSync("node_modules/.bin/changeset", ["status", "--output", out], {
-			stdio: "pipe",
-		});
+		execFileSync(bin, ["status", "--output", out], { stdio: "pipe" });
 		return { plan: JSON.parse(readFileSync(out, "utf-8")), error: null };
 	} catch (cause) {
 		return { plan: null, error: String(cause.stderr ?? cause.message).trim() };
@@ -187,8 +222,19 @@ const main = () => {
 	const publishedNames = PACKAGES.map(
 		(dir) => JSON.parse(readFileSync(`${dir}/package.json`, "utf-8")).name,
 	);
-	const addedIds = changed
-		.filter((file) => file.startsWith(".changeset/") && file.endsWith(".md"))
+	// Added, not merely changed: editing a changeset that already sits on the
+	// base branch must not count as coverage this branch brought, or a breaking
+	// change could ride along on somebody else's patch entry. Untracked files
+	// are added by definition, and are what a local run before committing sees.
+	const addedIds = [
+		...lines(
+			git("diff", "--name-only", "--diff-filter=A", since, "--", ".changeset"),
+		),
+		...lines(
+			git("ls-files", "--others", "--exclude-standard", "--", ".changeset"),
+		),
+	]
+		.filter((file) => file.endsWith(".md"))
 		.map((file) => basename(file, ".md"));
 
 	const { plan, error } = releasePlan();

--- a/scripts/check-changeset-needed.provenance.test.mjs
+++ b/scripts/check-changeset-needed.provenance.test.mjs
@@ -1,0 +1,324 @@
+/**
+ * End-to-end tests for the changeset gate, driven against throwaway git
+ * repositories.
+ *
+ * The unit tests cover the pure helpers; these cover what the helpers cannot
+ * see — where a path came from. Whether a changeset was *added* by the branch
+ * or merely edited, and what the merge base was, are answered by git, so the
+ * only honest way to test them is to build a repository that has that history
+ * and run the real script against it.
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+
+// Each case boots the Changesets CLI in a child process, and they all run at
+// once — well past the default per-test timeout on a loaded machine.
+vi.setConfig({ testTimeout: 60_000 });
+
+const SCRIPT = join(import.meta.dirname, "check-changeset-needed.mjs");
+
+const CORE = {
+	name: "@kheopskit/core",
+	version: "1.0.0",
+	exports: {
+		".": {
+			import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+		},
+	},
+	files: ["dist"],
+	dependencies: { "lodash-es": "^4.17.21" },
+	devDependencies: { vitest: "^3.0.0" },
+};
+
+const REACT = {
+	name: "@kheopskit/react",
+	version: "1.0.0",
+	exports: { ".": "./dist/index.mjs" },
+	files: ["dist"],
+};
+
+const CONFIG = {
+	changelog: false,
+	commit: false,
+	access: "public",
+	baseBranch: "main",
+	updateInternalDependencies: "patch",
+	fixed: [["kheopskit", "@kheopskit/core", "@kheopskit/react"]],
+	ignore: ["vite-react"],
+};
+
+const changeset = (pkg, type, summary) =>
+	`---\n"${pkg}": ${type}\n---\n\n${summary}\n`;
+
+const git = (cwd, ...args) =>
+	execFileSync("git", args, { cwd, encoding: "utf-8" });
+
+const write = (repo, path, content) => {
+	mkdirSync(join(repo, dirname(path)), { recursive: true });
+	writeFileSync(
+		join(repo, path),
+		typeof content === "string"
+			? content
+			: `${JSON.stringify(content, null, 2)}\n`,
+	);
+};
+
+/**
+ * A repository shaped like this one — a private root in a fixed group with two
+ * published packages — sitting on a branch that has diverged from `main`.
+ */
+const fixture = ({ base = {}, ...rest } = {}) => {
+	// A typo here silently produces a repository where the "base" file was added
+	// by the branch — which is exactly what the provenance tests assert against.
+	const unknown = Object.keys(rest);
+	if (unknown.length) throw new Error(`unknown fixture option: ${unknown}`);
+
+	const repo = mkdtempSync(join(tmpdir(), "changeset-gate-test-"));
+	onTestFinished(() => rmSync(repo, { recursive: true, force: true }));
+
+	git(repo, "init", "-q", "-b", "main");
+	git(repo, "config", "user.email", "gate@test.invalid");
+	git(repo, "config", "user.name", "gate");
+
+	write(repo, "package.json", {
+		name: "kheopskit",
+		private: true,
+		version: "1.0.0",
+	});
+	write(
+		repo,
+		"pnpm-workspace.yaml",
+		"packages:\n  - packages/*\n  - examples/*\n  - .\n",
+	);
+	write(repo, "tsconfig.base.json", { compilerOptions: { target: "ES2022" } });
+	write(repo, ".changeset/config.json", CONFIG);
+	write(repo, "packages/core/package.json", CORE);
+	write(repo, "packages/core/src/index.ts", "export const version = 1;\n");
+	write(repo, "packages/react/package.json", REACT);
+	write(repo, "packages/react/src/index.ts", "export const version = 1;\n");
+	// Present so the `ignore` list resolves, and so a changeset can name it.
+	write(repo, "examples/vite-react/package.json", {
+		name: "vite-react",
+		private: true,
+		version: "0.0.0",
+	});
+	for (const [path, content] of Object.entries(base))
+		write(repo, path, content);
+
+	git(repo, "add", "-A");
+	git(repo, "commit", "-qm", "init");
+	git(repo, "checkout", "-qb", "feature");
+
+	// The base branch keeps moving under real PRs; every scenario runs against a
+	// merge base, so this must never leak into what the branch looks like.
+	git(repo, "checkout", "-q", "main");
+	write(repo, "README.md", "moved on\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-qm", "unrelated base commit");
+	git(repo, "checkout", "-q", "feature");
+
+	return repo;
+};
+
+const commit = (repo, message) => {
+	git(repo, "add", "-A");
+	git(repo, "commit", "-qm", message);
+};
+
+/**
+ * Runs the real script against `repo`. Asynchronous so the cases can overlap:
+ * almost all of the wall clock is booting the Changesets CLI once per case.
+ */
+const gate = (repo) =>
+	new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [SCRIPT], {
+			cwd: repo,
+			env: { ...process.env, BASE_REF: "main" },
+		});
+		let output = "";
+		child.stdout.setEncoding("utf-8").on("data", (chunk) => {
+			output += chunk;
+		});
+		child.stderr.setEncoding("utf-8").on("data", (chunk) => {
+			output += chunk;
+		});
+		child.on("error", reject);
+		child.on("close", (status) => resolve({ status, output }));
+	});
+
+// Each case is an independent repository and an independent child process, and
+// most of the wall clock is booting the Changesets CLI — so run them at once.
+describe.concurrent("changeset gate", () => {
+	it("passes when nothing published changed", async () => {
+		const repo = fixture();
+		write(repo, "examples/app/main.ts", "console.log(1);\n");
+		commit(repo, "example only");
+
+		expect((await gate(repo)).output).toContain("No published package changed");
+	});
+
+	it("fails when source changes with no changeset", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		commit(repo, "source");
+
+		const { status, output } = await gate(repo);
+		expect(status).toBe(1);
+		expect(output).toContain("Missing changeset.");
+		expect(output).toContain("packages/core/src/index.ts");
+	});
+
+	it("passes when the branch adds a changeset", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		write(
+			repo,
+			".changeset/brave-pandas-sing.md",
+			changeset("@kheopskit/core", "patch", "fix"),
+		);
+		commit(repo, "source + changeset");
+
+		expect((await gate(repo)).status).toBe(0);
+	});
+
+	// What a local run before committing sees.
+	it("counts an uncommitted changeset", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		write(
+			repo,
+			".changeset/brave-pandas-sing.md",
+			changeset("@kheopskit/core", "patch", "fix"),
+		);
+
+		expect((await gate(repo)).status).toBe(0);
+	});
+
+	// Provenance: the changeset exists and releases core, but it came from the
+	// base branch. Editing it must not launder an unrelated change into the
+	// release — it would ship with no changelog entry of its own.
+	it("rejects a changeset the branch only edited", async () => {
+		const repo = fixture({
+			base: {
+				".changeset/tidy-moons-wave.md": changeset(
+					"@kheopskit/core",
+					"patch",
+					"someone else's fix",
+				),
+			},
+		});
+		write(
+			repo,
+			".changeset/tidy-moons-wave.md",
+			changeset("@kheopskit/core", "patch", "someone else's fix, retyped"),
+		);
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		commit(repo, "edit base changeset + source");
+
+		const { status, output } = await gate(repo);
+		expect(status).toBe(1);
+		expect(output).toContain("Missing changeset on this branch.");
+	});
+
+	// Control for the above: same base changeset present and untouched, branch
+	// adds its own — the base one being there is not itself the problem.
+	it("accepts its own changeset alongside a base one", async () => {
+		const repo = fixture({
+			base: {
+				".changeset/tidy-moons-wave.md": changeset(
+					"@kheopskit/core",
+					"patch",
+					"someone else's fix",
+				),
+			},
+		});
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		write(
+			repo,
+			".changeset/brave-pandas-sing.md",
+			changeset("@kheopskit/core", "patch", "fix"),
+		);
+		commit(repo, "source + changeset");
+
+		expect((await gate(repo)).status).toBe(0);
+	});
+
+	// Nothing under packages/ moved, yet both build tsconfigs extend this file.
+	it("fails on a shared build input change", async () => {
+		const repo = fixture();
+		write(repo, "tsconfig.base.json", {
+			compilerOptions: { target: "ES2017" },
+		});
+		commit(repo, "lower the target");
+
+		const { status, output } = await gate(repo);
+		expect(status).toBe(1);
+		expect(output).toContain("tsconfig.base.json");
+	});
+
+	it("ignores a devDependency bump", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/package.json", {
+			...CORE,
+			devDependencies: { vitest: "^4.0.0" },
+		});
+		commit(repo, "bump devDep");
+
+		expect((await gate(repo)).output).toContain("No published package changed");
+	});
+
+	it("fails on a dependency range bump", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/package.json", {
+			...CORE,
+			dependencies: { "lodash-es": "^5.0.0" },
+		});
+		commit(repo, "bump dep");
+
+		const { status, output } = await gate(repo);
+		expect(status).toBe(1);
+		expect(output).toContain("packages/core/package.json");
+	});
+
+	// Every key and value is identical; only the condition order moved.
+	it("fails on a reordered export condition", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/package.json", {
+			...CORE,
+			exports: {
+				".": {
+					import: { default: "./dist/index.mjs", types: "./dist/index.d.mts" },
+				},
+			},
+		});
+		commit(repo, "reorder exports");
+
+		expect((await gate(repo)).status).toBe(1);
+	});
+
+	// An ignored package releases nothing, so a changeset naming only it cannot
+	// cover a real change.
+	it("rejects a changeset that releases only an ignored package", async () => {
+		const repo = fixture();
+		write(repo, "packages/core/src/index.ts", "export const version = 2;\n");
+		write(
+			repo,
+			".changeset/quiet-lions-nap.md",
+			changeset("vite-react", "patch", "example"),
+		);
+		commit(repo, "source + example changeset");
+
+		expect((await gate(repo)).status).toBe(1);
+	});
+
+	// The base branch moved on with an unrelated commit in every fixture; a
+	// two-dot diff against the tip would drag README.md in.
+	it("diffs from the merge base, not the base tip", async () => {
+		const repo = fixture();
+
+		expect((await gate(repo)).output).toContain("No published package changed");
+	});
+});

--- a/scripts/check-changeset-needed.test.mjs
+++ b/scripts/check-changeset-needed.test.mjs
@@ -19,17 +19,47 @@ describe("publishedManifest", () => {
 		);
 	});
 
-	it("is insensitive to key order and array entry order", () => {
+	it("is insensitive to key order", () => {
 		expect(
 			publishedManifest({
 				dependencies: { b: "^1", a: "^1" },
-				files: ["README.md", "dist"],
+				files: ["dist"],
 			}),
 		).toBe(
 			publishedManifest({
-				files: ["dist", "README.md"],
+				files: ["dist"],
 				dependencies: { a: "^1", b: "^1" },
 			}),
+		);
+	});
+
+	// Node takes the first condition that matches, so `default` above `types`
+	// changes what consumers resolve without any key or value moving.
+	it("detects a reordered export condition", () => {
+		expect(
+			publishedManifest({
+				exports: {
+					".": { types: "./dist/index.d.ts", default: "./dist/index.mjs" },
+				},
+			}),
+		).not.toBe(
+			publishedManifest({
+				exports: {
+					".": { default: "./dist/index.mjs", types: "./dist/index.d.ts" },
+				},
+			}),
+		);
+	});
+
+	// An `exports` fallback array is resolved in order too.
+	it("detects a reordered array", () => {
+		expect(
+			publishedManifest({ exports: { ".": ["./dist/a.mjs", "./dist/b.mjs"] } }),
+		).not.toBe(
+			publishedManifest({ exports: { ".": ["./dist/b.mjs", "./dist/a.mjs"] } }),
+		);
+		expect(publishedManifest({ files: ["dist", "README.md"] })).not.toBe(
+			publishedManifest({ files: ["README.md", "dist"] }),
 		);
 	});
 
@@ -102,6 +132,12 @@ describe("affectsPublishedArtifact", () => {
 	// Compared field-wise instead, so a devDependency bump is not a change.
 	it("leaves package.json to the manifest comparison", () => {
 		expect(affectsPublishedArtifact("packages/core/package.json")).toBe(false);
+	});
+
+	// Both build tsconfigs extend it, so a compiler option there rewrites the
+	// emitted output of packages whose own files never moved.
+	it("counts shared build inputs", () => {
+		expect(affectsPublishedArtifact("tsconfig.base.json")).toBe(true);
 	});
 
 	it("ignores everything outside the published packages", () => {

--- a/scripts/check-changeset-needed.test.mjs
+++ b/scripts/check-changeset-needed.test.mjs
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { dependencyContract, planCoverage } from "./check-changeset-needed.mjs";
+
+describe("dependencyContract", () => {
+	it("ignores fields that never reach npm", () => {
+		const base = {
+			name: "@kheopskit/core",
+			dependencies: { "lodash-es": "^4" },
+		};
+		expect(
+			dependencyContract({ ...base, devDependencies: { viem: "^2" } }),
+		).toBe(dependencyContract({ ...base, devDependencies: { viem: "^3" } }));
+		expect(dependencyContract({ ...base, version: "1.0.0" })).toBe(
+			dependencyContract({ ...base, version: "2.0.0" }),
+		);
+	});
+
+	it("is insensitive to key order and bundled entry order", () => {
+		expect(
+			dependencyContract({
+				dependencies: { b: "^1", a: "^1" },
+				bundledDependencies: ["b", "a"],
+			}),
+		).toBe(
+			dependencyContract({
+				bundledDependencies: ["a", "b"],
+				dependencies: { a: "^1", b: "^1" },
+			}),
+		);
+	});
+
+	it("detects a dependency range change", () => {
+		expect(
+			dependencyContract({ dependencies: { "@scure/base": "^1" } }),
+		).not.toBe(dependencyContract({ dependencies: { "@scure/base": "^2" } }));
+	});
+
+	// The case that motivated widening beyond `dependencies`/`peerDependencies`:
+	// no version string moves, but the peer stops being optional.
+	it("detects an optional peer becoming required", () => {
+		const peerDependencies = { viem: ">=2.0.0" };
+		expect(
+			dependencyContract({
+				peerDependencies,
+				peerDependenciesMeta: { viem: { optional: true } },
+			}),
+		).not.toBe(dependencyContract({ peerDependencies }));
+	});
+
+	it("detects added optional and bundled dependencies", () => {
+		expect(dependencyContract({})).not.toBe(
+			dependencyContract({ optionalDependencies: { fsevents: "^2" } }),
+		);
+		expect(dependencyContract({})).not.toBe(
+			dependencyContract({ bundledDependencies: ["lodash-es"] }),
+		);
+	});
+});
+
+describe("planCoverage", () => {
+	const published = ["@kheopskit/core", "@kheopskit/react"];
+
+	it("treats a refused plan as covering nothing", () => {
+		expect(planCoverage(null, published)).toEqual({
+			releasesPublished: false,
+			drivingIds: new Set(),
+		});
+	});
+
+	// An `--empty` changeset, a dot-prefixed file, or one naming only an ignored
+	// example all land here: Changesets reports the published packages as
+	// `none`, so nothing is actually released.
+	it("does not count releases of type none", () => {
+		const plan = {
+			releases: [
+				{ name: "@kheopskit/core", type: "none", changesets: [] },
+				{ name: "vite-react", type: "none", changesets: ["ignored-only"] },
+			],
+		};
+		expect(planCoverage(plan, published)).toEqual({
+			releasesPublished: false,
+			drivingIds: new Set(),
+		});
+	});
+
+	// The fixed group bumps react and the root alongside core, but attributes
+	// the changeset id only to the package the changeset named.
+	it("collects driving ids across the whole fixed group", () => {
+		const plan = {
+			releases: [
+				{
+					name: "@kheopskit/core",
+					type: "patch",
+					changesets: ["noble-hashes"],
+				},
+				{ name: "@kheopskit/react", type: "patch", changesets: [] },
+				{ name: "kheopskit", type: "patch", changesets: [] },
+				{ name: "vite-react", type: "none", changesets: [] },
+			],
+		};
+		expect(planCoverage(plan, published)).toEqual({
+			releasesPublished: true,
+			drivingIds: new Set(["noble-hashes"]),
+		});
+	});
+
+	it("counts a changeset that names only the private root package", () => {
+		const plan = {
+			releases: [
+				{ name: "kheopskit", type: "patch", changesets: ["root-only"] },
+				{ name: "@kheopskit/core", type: "patch", changesets: [] },
+			],
+		};
+		const { releasesPublished, drivingIds } = planCoverage(plan, published);
+		expect(releasesPublished).toBe(true);
+		expect(drivingIds).toEqual(new Set(["root-only"]));
+	});
+});

--- a/scripts/check-changeset-needed.test.mjs
+++ b/scripts/check-changeset-needed.test.mjs
@@ -1,29 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { dependencyContract, planCoverage } from "./check-changeset-needed.mjs";
+import {
+	affectsPublishedArtifact,
+	planCoverage,
+	publishedManifest,
+} from "./check-changeset-needed.mjs";
 
-describe("dependencyContract", () => {
-	it("ignores fields that never reach npm", () => {
+describe("publishedManifest", () => {
+	it("ignores the fields consumers never observe", () => {
 		const base = {
 			name: "@kheopskit/core",
 			dependencies: { "lodash-es": "^4" },
 		};
 		expect(
-			dependencyContract({ ...base, devDependencies: { viem: "^2" } }),
-		).toBe(dependencyContract({ ...base, devDependencies: { viem: "^3" } }));
-		expect(dependencyContract({ ...base, version: "1.0.0" })).toBe(
-			dependencyContract({ ...base, version: "2.0.0" }),
+			publishedManifest({ ...base, devDependencies: { viem: "^2" } }),
+		).toBe(publishedManifest({ ...base, devDependencies: { viem: "^3" } }));
+		expect(publishedManifest({ ...base, version: "1.0.0" })).toBe(
+			publishedManifest({ ...base, version: "2.0.0" }),
 		);
 	});
 
-	it("is insensitive to key order and bundled entry order", () => {
+	it("is insensitive to key order and array entry order", () => {
 		expect(
-			dependencyContract({
+			publishedManifest({
 				dependencies: { b: "^1", a: "^1" },
-				bundledDependencies: ["b", "a"],
+				files: ["README.md", "dist"],
 			}),
 		).toBe(
-			dependencyContract({
-				bundledDependencies: ["a", "b"],
+			publishedManifest({
+				files: ["dist", "README.md"],
 				dependencies: { a: "^1", b: "^1" },
 			}),
 		);
@@ -31,29 +35,84 @@ describe("dependencyContract", () => {
 
 	it("detects a dependency range change", () => {
 		expect(
-			dependencyContract({ dependencies: { "@scure/base": "^1" } }),
-		).not.toBe(dependencyContract({ dependencies: { "@scure/base": "^2" } }));
+			publishedManifest({ dependencies: { "@scure/base": "^1" } }),
+		).not.toBe(publishedManifest({ dependencies: { "@scure/base": "^2" } }));
 	});
 
-	// The case that motivated widening beyond `dependencies`/`peerDependencies`:
-	// no version string moves, but the peer stops being optional.
+	// No version string moves here, but the peer stops being optional.
 	it("detects an optional peer becoming required", () => {
 		const peerDependencies = { viem: ">=2.0.0" };
 		expect(
-			dependencyContract({
+			publishedManifest({
 				peerDependencies,
 				peerDependenciesMeta: { viem: { optional: true } },
 			}),
-		).not.toBe(dependencyContract({ peerDependencies }));
+		).not.toBe(publishedManifest({ peerDependencies }));
 	});
 
-	it("detects added optional and bundled dependencies", () => {
-		expect(dependencyContract({})).not.toBe(
-			dependencyContract({ optionalDependencies: { fsevents: "^2" } }),
+	// Comparing everything but the excluded fields means these need no
+	// enumeration to be caught.
+	it("detects changes to fields nobody enumerated", () => {
+		expect(
+			publishedManifest({ exports: { ".": "./dist/index.mjs" } }),
+		).not.toBe(publishedManifest({ exports: { ".": "./dist/main.mjs" } }));
+		expect(publishedManifest({ files: ["dist"] })).not.toBe(
+			publishedManifest({ files: ["dist", "README.md"] }),
 		);
-		expect(dependencyContract({})).not.toBe(
-			dependencyContract({ bundledDependencies: ["lodash-es"] }),
+		expect(publishedManifest({ engines: { node: ">=22" } })).not.toBe(
+			publishedManifest({ engines: { node: ">=24" } }),
 		);
+		expect(publishedManifest({ tsdown: { target: "es2020" } })).not.toBe(
+			publishedManifest({ tsdown: { target: "es2022" } }),
+		);
+		expect(publishedManifest({})).not.toBe(
+			publishedManifest({ optionalDependencies: { fsevents: "^2" } }),
+		);
+	});
+});
+
+describe("affectsPublishedArtifact", () => {
+	it("counts source and shipped docs", () => {
+		expect(affectsPublishedArtifact("packages/core/src/index.ts")).toBe(true);
+		expect(affectsPublishedArtifact("packages/react/src/nested/deep.tsx")).toBe(
+			true,
+		);
+		expect(affectsPublishedArtifact("packages/core/README.md")).toBe(true);
+		expect(affectsPublishedArtifact("packages/core/MIGRATING_TO_V4.md")).toBe(
+			true,
+		);
+		expect(affectsPublishedArtifact("packages/core/tsconfig.build.json")).toBe(
+			true,
+		);
+	});
+
+	it("skips what cannot reach the tarball", () => {
+		expect(affectsPublishedArtifact("packages/core/src/ssr.test.ts")).toBe(
+			false,
+		);
+		expect(affectsPublishedArtifact("packages/react/src/store.test.tsx")).toBe(
+			false,
+		);
+		expect(affectsPublishedArtifact("packages/core/CHANGELOG.md")).toBe(false);
+		expect(affectsPublishedArtifact("packages/core/tsconfig.tsbuildinfo")).toBe(
+			false,
+		);
+	});
+
+	// Compared field-wise instead, so a devDependency bump is not a change.
+	it("leaves package.json to the manifest comparison", () => {
+		expect(affectsPublishedArtifact("packages/core/package.json")).toBe(false);
+	});
+
+	it("ignores everything outside the published packages", () => {
+		for (const file of [
+			"examples/vite-react/src/main.tsx",
+			".github/workflows/ci.yml",
+			"pnpm-lock.yaml",
+			"scripts/check-changeset-needed.mjs",
+			"packages-not-really/core/src/index.ts",
+		])
+			expect(affectsPublishedArtifact(file)).toBe(false);
 	});
 });
 
@@ -111,8 +170,9 @@ describe("planCoverage", () => {
 				{ name: "@kheopskit/core", type: "patch", changesets: [] },
 			],
 		};
-		const { releasesPublished, drivingIds } = planCoverage(plan, published);
-		expect(releasesPublished).toBe(true);
-		expect(drivingIds).toEqual(new Set(["root-only"]));
+		expect(planCoverage(plan, published)).toEqual({
+			releasesPublished: true,
+			drivingIds: new Set(["root-only"]),
+		});
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
 		globals: true,
 		environment: "jsdom",
 		setupFiles: ["./vitest.setup.ts"],
-		include: ["packages/**/*.test.ts", "packages/**/*.test.tsx"],
+		include: [
+			"packages/**/*.test.ts",
+			"packages/**/*.test.tsx",
+			"scripts/**/*.test.mjs",
+		],
 	},
 });


### PR DESCRIPTION
Nothing enforced that a change reaching `@kheopskit/core` or `@kheopskit/react` came with a changeset, so a bump-and-republish could be forgotten silently.

`scripts/check-changeset-needed.mjs` fails a PR that changes a published package without adding a changeset that actually releases it. A change counts when it can reach the npm tarball:

- source under `packages/*/src`, the files listed in `files`, and the build config
- `package.json` compared field-wise, excluding `version` (Changesets owns it) and `devDependencies` (published but never installed for consumers)

Tests, `CHANGELOG.md`, examples, workflows and the lockfile leave the published artifact byte-identical and are ignored — a check that fails on nearly every PR is one everybody learns to bypass.

Coverage is decided by `changeset status` rather than by filename, so an `--empty` changeset, a dot-prefixed file, or one naming only an ignored example correctly counts for nothing. The release must also be driven by a changeset *this branch added*, so a changeset already on the base branch can't silently cover a new change.

Runs as the last step of `Quality` (renamed from `Lint, typecheck and unit tests`) under `!cancelled()`, so a lint failure doesn't hide a missing changeset. The release PR is exempt — it rewrites peerDependencies while deleting the changesets it consumed — and the exemption checks the head repo, since a fork could otherwise just name its branch `changeset-release/main`.

Dependabot gets a `runtime` group for core's shipped deps so the changeset rides a small PR. The list is ergonomics only; the gate keys off the diff.

13 unit tests, plus the matrix verified end to end: source / README / exports / runtime dep / optional-peer-to-required all fail without a changeset; tests / CHANGELOG / examples / devDep bumps / version / key reordering all pass.
